### PR TITLE
Resolved .env relative directory issue

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -44,7 +44,7 @@ const __dirname = path.dirname(__filename);
 // ==========================
 
 // Load environment variables from .env file into process.env
-dotenv.config();
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 // ==========================
 // Middleware Configuration


### PR DESCRIPTION
When calling server.js from outside the folder 'backend' the environment variables loaded improperly.