### PR TITLE
[native] Fixing GH Actions build

### DIFF
--- a/.github/workflows/expo-build.yml
+++ b/.github/workflows/expo-build.yml
@@ -99,28 +99,35 @@ jobs:
         working-directory: ./recipestore-app
         id: build-url
         run: |
+          set +e  # Don't exit on error
+          
           # Wait for build to be indexed
           echo "Waiting for build to be indexed..."
           sleep 10
           
-          # Get the build list and check if valid
+          # Get the build list
           BUILD_LIST=$(eas build:list --platform=android --limit=1 --json 2>&1)
+          EAS_EXIT_CODE=$?
+          
+          echo "EAS exit code: $EAS_EXIT_CODE"
           echo "Build list response: $BUILD_LIST"
           
-          # Check if the response is valid JSON
-          if echo "$BUILD_LIST" | jq empty 2>/dev/null; then
-            BUILD_URL=$(echo "$BUILD_LIST" | jq -r '.[0].artifacts.buildUrl // ""')
-            if [ -z "$BUILD_URL" ] || [ "$BUILD_URL" = "null" ]; then
-              echo "⚠️ No build URL found in response"
-              BUILD_URL="https://expo.dev/accounts/$(whoami)/projects/recipestore-app/builds"
-            fi
-          else
-            echo "⚠️ Invalid JSON response from eas build:list"
-            BUILD_URL="https://expo.dev/accounts/$(whoami)/projects/recipestore-app/builds"
+          # Try to parse the JSON and get URL
+          BUILD_URL=""
+          if [ $EAS_EXIT_CODE -eq 0 ]; then
+            BUILD_URL=$(echo "$BUILD_LIST" | jq -r '.[0].artifacts.buildUrl // ""' 2>/dev/null || echo "")
+          fi
+          
+          # Use fallback URL if needed
+          if [ -z "$BUILD_URL" ] || [ "$BUILD_URL" = "null" ]; then
+            echo "⚠️ Could not get build URL, using builds page"
+            BUILD_URL="https://expo.dev/accounts/o-kennedevworks/projects/recipestore-app/builds"
           fi
           
           echo "Final build URL: $BUILD_URL"
           echo "url=$BUILD_URL" >> $GITHUB_OUTPUT
+          
+          set -e  # Re-enable exit on error
 
       - name: Create Release
         uses: actions/github-script@v7

--- a/.github/workflows/expo-update-schedule.yml
+++ b/.github/workflows/expo-update-schedule.yml
@@ -48,28 +48,35 @@ jobs:
         working-directory: ./recipestore-app
         id: build-url
         run: |
+          set +e  # Don't exit on error
+          
           # Wait for build to be indexed
           echo "Waiting for build to be indexed..."
           sleep 10
           
-          # Get the build list and check if valid
+          # Get the build list
           BUILD_LIST=$(eas build:list --platform=android --limit=1 --json 2>&1)
+          EAS_EXIT_CODE=$?
+          
+          echo "EAS exit code: $EAS_EXIT_CODE"
           echo "Build list response: $BUILD_LIST"
           
-          # Check if the response is valid JSON
-          if echo "$BUILD_LIST" | jq empty 2>/dev/null; then
-            BUILD_URL=$(echo "$BUILD_LIST" | jq -r '.[0].artifacts.buildUrl // ""')
-            if [ -z "$BUILD_URL" ] || [ "$BUILD_URL" = "null" ]; then
-              echo "⚠️ No build URL found in response"
-              BUILD_URL="https://expo.dev/accounts/$(whoami)/projects/recipestore-app/builds"
-            fi
-          else
-            echo "⚠️ Invalid JSON response from eas build:list"
-            BUILD_URL="https://expo.dev/accounts/$(whoami)/projects/recipestore-app/builds"
+          # Try to parse the JSON and get URL
+          BUILD_URL=""
+          if [ $EAS_EXIT_CODE -eq 0 ]; then
+            BUILD_URL=$(echo "$BUILD_LIST" | jq -r '.[0].artifacts.buildUrl // ""' 2>/dev/null || echo "")
+          fi
+          
+          # Use fallback URL if needed
+          if [ -z "$BUILD_URL" ] || [ "$BUILD_URL" = "null" ]; then
+            echo "⚠️ Could not get build URL, using builds page"
+            BUILD_URL="https://expo.dev/accounts/o-kennedevworks/projects/recipestore-app/builds"
           fi
           
           echo "Final build URL: $BUILD_URL"
           echo "url=$BUILD_URL" >> $GITHUB_OUTPUT
+          
+          set -e  # Re-enable exit on error
 
       - name: Create Release
         uses: actions/github-script@v7


### PR DESCRIPTION
This pull request improves the reliability and error handling of the build URL extraction step in two GitHub Actions workflows. The main changes involve making the shell script more robust when fetching and parsing the Expo build list, ensuring that failures are handled gracefully and a fallback URL is always provided.

**Improvements to build URL extraction and error handling:**

* The shell script now disables immediate exit on errors (`set +e`) during the build URL extraction, allowing the workflow to continue even if the Expo CLI or JSON parsing fails. It re-enables error exit (`set -e`) after the step is complete. (.github/workflows/expo-build.yml [[1]](diffhunk://#diff-261b938d635f69ab2951f05b9b27c41de9a2879904a6e9287b52a31ff97e1ebeR102-R131) .github/workflows/expo-update-schedule.yml [[2]](diffhunk://#diff-b73902b9b7a9c599a637350188c89fa5efec7b8a98b0c5c2ccd2de36073297d7R51-R80)
* The script captures the exit code from the Expo CLI (`eas build:list`) and only attempts to parse the build list JSON if the command succeeds. (.github/workflows/expo-build.yml [[1]](diffhunk://#diff-261b938d635f69ab2951f05b9b27c41de9a2879904a6e9287b52a31ff97e1ebeR102-R131) .github/workflows/expo-update-schedule.yml [[2]](diffhunk://#diff-b73902b9b7a9c599a637350188c89fa5efec7b8a98b0c5c2ccd2de36073297d7R51-R80)
* If the build URL cannot be parsed or is missing, the script logs a warning and uses a fallback URL that points to the project's builds page. The fallback now uses a hardcoded account/project instead of relying on `whoami`. (.github/workflows/expo-build.yml [[1]](diffhunk://#diff-261b938d635f69ab2951f05b9b27c41de9a2879904a6e9287b52a31ff97e1ebeR102-R131) .github/workflows/expo-update-schedule.yml [[2]](diffhunk://#diff-b73902b9b7a9c599a637350188c89fa5efec7b8a98b0c5c2ccd2de36073297d7R51-R80)